### PR TITLE
Consolidate flag suffix mapping

### DIFF
--- a/ThisWorkbook
+++ b/ThisWorkbook
@@ -43,21 +43,7 @@ Private Sub Workbook_SheetChange(ByVal sh As Object, ByVal Target As Range)
     If wo = "" Then GoTo ExitHandler
 
     ' 5) Map to suffix for flag columns
-    Select Case prefix & "|" & hdr
-      Case "Design|Designed":     suffix = "Designed"
-      Case "Design|Redesigned":   suffix = "Redesigned"
-      Case "Printing|Printed":    suffix = "Printed"
-      Case "Printing|Redesign":   suffix = "Redesign"
-      Case "Printing|Reprinted":  suffix = "Reprinted"
-      Case "Prod|Complete":       suffix = "Complete"
-      Case "Prod|Reprint":        suffix = "Reprint"
-      Case "Prod|Rechecked":      suffix = "Rechecked"
-      Case "Ship|InstallReady":   suffix = "InstallReady"
-      Case "Ship|Shipped":        suffix = "Shipped"
-      Case "Ship|Recheck":        suffix = "Recheck"
-      Case Else
-        suffix = Replace(hdr, " ", "")
-    End Select
+    suffix = GetFlagSuffix(prefix, hdr)
     masterField = prefix & "_" & suffix
 
     ' 6) Write the checkbox back to Master

--- a/modFlagSync
+++ b/modFlagSync
@@ -30,21 +30,7 @@ Public Sub SyncFlagToMaster(sh As Worksheet, ByVal Target As Range)
     If hdr = "" Then Exit Sub
 
     ' Map header to suffix
-    Select Case prefix & "|" & hdr
-      Case "Design|Designed":     suffix = "Designed"
-      Case "Design|Redesigned":   suffix = "Redesigned"
-      Case "Printing|Printed":    suffix = "Printed"
-      Case "Printing|Redesign":   suffix = "Redesign"
-      Case "Printing|Reprinted":  suffix = "Reprinted"
-      Case "Prod|Complete":       suffix = "Complete"
-      Case "Prod|Reprint":        suffix = "Reprint"
-      Case "Prod|Rechecked":      suffix = "Rechecked"
-      Case "Ship|InstallReady":   suffix = "InstallReady"
-      Case "Ship|Shipped":        suffix = "Shipped"
-      Case "Ship|Recheck":        suffix = "Recheck"
-      Case Else
-        suffix = Replace(hdr, " ", "")
-    End Select
+    suffix = GetFlagSuffix(prefix, hdr)
 
     masterField = prefix & "_" & suffix
 

--- a/modSyncHelpers
+++ b/modSyncHelpers
@@ -40,3 +40,22 @@ Public Sub RefreshStageSheet(sheetName As String)
     Application.CutCopyMode = False
     Application.ScreenUpdating = True
 End Sub
+
+''' Returns the standardized suffix for a flag column
+Public Function GetFlagSuffix(prefix As String, hdr As String) As String
+    Select Case prefix & "|" & hdr
+      Case "Design|Designed":     GetFlagSuffix = "Designed"
+      Case "Design|Redesigned":   GetFlagSuffix = "Redesigned"
+      Case "Printing|Printed":    GetFlagSuffix = "Printed"
+      Case "Printing|Redesign":   GetFlagSuffix = "Redesign"
+      Case "Printing|Reprinted":  GetFlagSuffix = "Reprinted"
+      Case "Prod|Complete":       GetFlagSuffix = "Complete"
+      Case "Prod|Reprint":        GetFlagSuffix = "Reprint"
+      Case "Prod|Rechecked":      GetFlagSuffix = "Rechecked"
+      Case "Ship|InstallReady":   GetFlagSuffix = "InstallReady"
+      Case "Ship|Shipped":        GetFlagSuffix = "Shipped"
+      Case "Ship|Recheck":        GetFlagSuffix = "Recheck"
+      Case Else
+        GetFlagSuffix = Replace(hdr, " ", "")
+    End Select
+End Function


### PR DESCRIPTION
## Summary
- add `GetFlagSuffix` helper to centralize flag suffix mapping
- use the helper in `ThisWorkbook` and `modFlagSync`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685d69ed65a48323a06b5a4ad23499dd