### PR TITLE
Handle missing AutoFilter when refreshing stages

### DIFF
--- a/modStageSync
+++ b/modStageSync
@@ -31,7 +31,9 @@ Public Sub RefreshAllStages()
         End If
 
         ' Remove filter
-        mTbl.AutoFilter.ShowAllData
+        On Error Resume Next
+          mTbl.AutoFilter.ShowAllData
+        On Error GoTo 0
     Next ws
 
     Application.CutCopyMode = False

--- a/modSyncHelpers
+++ b/modSyncHelpers
@@ -36,7 +36,9 @@ Public Sub RefreshStageSheet(sheetName As String)
     End If
 
     ' Remove filter and reset
-    mTbl.AutoFilter.ShowAllData
+    On Error Resume Next
+      mTbl.AutoFilter.ShowAllData
+    On Error GoTo 0
     Application.CutCopyMode = False
     Application.ScreenUpdating = True
 End Sub


### PR DESCRIPTION
## Summary
- protect `AutoFilter.ShowAllData` in `RefreshStageSheet`
- mirror the same protection in `RefreshAllStages`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d69f1e9f88323bba32a97b9efe6eb