### PR TITLE
Add error handlers for stage refresh macros

### DIFF
--- a/modStageSync
+++ b/modStageSync
@@ -7,6 +7,8 @@ Public Sub RefreshAllStages()
     Dim hdrRow   As Range
     Dim visRange As Range
 
+    On Error GoTo ExitHandler
+
     Application.ScreenUpdating = False
 
     For Each ws In Sheets(Array("Order Entry", "Design", "Printing", "Production", "Shipping"))
@@ -34,6 +36,7 @@ Public Sub RefreshAllStages()
         mTbl.AutoFilter.ShowAllData
     Next ws
 
+ExitHandler:
     Application.CutCopyMode = False
     Application.ScreenUpdating = True
 End Sub

--- a/modSyncHelpers
+++ b/modSyncHelpers
@@ -18,6 +18,8 @@ Public Sub RefreshStageSheet(sheetName As String)
     Dim hdrRow   As Range:      Set hdrRow = subTbl.HeaderRowRange
     Dim visRange As Range
 
+    On Error GoTo ExitHandler
+
     Application.ScreenUpdating = False
 
     ' Clear existing body
@@ -37,6 +39,8 @@ Public Sub RefreshStageSheet(sheetName As String)
 
     ' Remove filter and reset
     mTbl.AutoFilter.ShowAllData
+
+ExitHandler:
     Application.CutCopyMode = False
     Application.ScreenUpdating = True
 End Sub


### PR DESCRIPTION
## Summary
- ensure RefreshStageSheet and RefreshAllStages always reset screen updating
- direct VBA errors to new ExitHandlers for cleanup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d69f63f488323bd2d06b2eca47741