### PR TITLE
Fix attachment sync and design sheet buttons

### DIFF
--- a/ThisWorkbook
+++ b/ThisWorkbook
@@ -1,7 +1,10 @@
 Option Explicit
 
 Private Sub Workbook_Open()
-    ' (Optional startup code here)
+    ' Initialize attachment buttons on the Design sheet
+    On Error Resume Next
+    AddDesignAttachButtons
+    On Error GoTo 0
 End Sub
 
 Private Sub Workbook_SheetChange(ByVal sh As Object, ByVal Target As Range)

--- a/modAttachBindings
+++ b/modAttachBindings
@@ -18,3 +18,22 @@ Public Sub Attach_OrderEntry_Click()
 
     ShowAttachForm rowIndex, "Order Entry"
 End Sub
+
+' Opens the file linked in the cell beneath a View button.
+Public Sub OpenAttachmentFromButton()
+    Dim btnName As String
+    Dim c As Range
+    Dim filePath As String
+
+    btnName = Application.Caller
+    On Error Resume Next
+        Set c = ActiveSheet.Shapes(btnName).TopLeftCell
+    On Error GoTo 0
+    If c Is Nothing Then Exit Sub
+
+    filePath = GetHyperlinkAddress(c)
+    If Len(filePath) = 0 Then filePath = CStr(c.Value)
+    If Len(Trim(filePath)) = 0 Then Exit Sub
+
+    ThisWorkbook.FollowHyperlink Address:=filePath
+End Sub

--- a/modDesignAttach
+++ b/modDesignAttach
@@ -5,30 +5,58 @@ Option Explicit
 ''' Adds “Attach” hyperlinks to any blank ProofPath/EmailPath/PrintPath cells
 ''' on the Design sheet’s table.
 Public Sub AddDesignAttachLinks()
+    ' Backwards compatibility wrapper
+    AddDesignAttachButtons
+End Sub
+
+''' Adds "Browse" or "View" buttons to ProofPath/EmailPath/PrintPath cells
+''' on the Design sheet.
+Public Sub AddDesignAttachButtons()
     Dim ws   As Worksheet:    Set ws   = ThisWorkbook.Sheets("Design")
     Dim tbl  As ListObject:   Set tbl  = ws.ListObjects("tblDesign")
     Dim pc   As Long:         pc     = tbl.ListColumns("ProofPath").Index
     Dim ec   As Long:         ec     = tbl.ListColumns("EmailPath").Index
     Dim rc   As Long:         rc     = tbl.ListColumns("PrintPath").Index
     Dim lr   As ListRow
+    Dim c    As Range
 
     For Each lr In tbl.ListRows
-        With lr.Range
-            If Len(Trim(.Cells(1, pc).Value)) = 0 Then
-                On Error Resume Next
-                ws.Hyperlinks.Add Anchor:=.Cells(1, pc), Address:="", SubAddress:="", TextToDisplay:="Attach"
-                On Error GoTo 0
-            End If
-            If Len(Trim(.Cells(1, ec).Value)) = 0 Then
-                On Error Resume Next
-                ws.Hyperlinks.Add Anchor:=.Cells(1, ec), Address:="", SubAddress:="", TextToDisplay:="Attach"
-                On Error GoTo 0
-            End If
-            If Len(Trim(.Cells(1, rc).Value)) = 0 Then
-                On Error Resume Next
-                ws.Hyperlinks.Add Anchor:=.Cells(1, rc), Address:="", SubAddress:="", TextToDisplay:="Attach"
-                On Error GoTo 0
-            End If
-        End With
+        For Each c In lr.Range.Columns(Array(pc, ec, rc)).Cells
+            UpdateAttachButton ws, c
+        Next c
     Next lr
+End Sub
+
+Private Sub UpdateAttachButton(ws As Worksheet, c As Range)
+    Dim btn     As Shape
+    Dim btnName As String
+    Dim fileAddr As String
+
+    btnName = "btn_" & c.Row & "_" & c.Column
+    On Error Resume Next
+        Set btn = ws.Shapes(btnName)
+    On Error GoTo 0
+
+    fileAddr = GetHyperlinkAddress(c)
+    If Len(fileAddr) = 0 Then fileAddr = Trim(CStr(c.Value))
+
+    If btn Is Nothing Then
+        Set btn = ws.Shapes.AddShape(msoShapeRectangle, c.Left, c.Top, c.Width, c.Height)
+        btn.Name = btnName
+        btn.TextFrame.HorizontalAlignment = xlHAlignCenter
+        btn.TextFrame.VerticalAlignment = xlVAlignCenter
+    End If
+
+    btn.Top = c.Top
+    btn.Left = c.Left
+    btn.Width = c.Width
+    btn.Height = c.Height
+
+    If Len(fileAddr) > 0 Then
+        btn.TextFrame.Characters.Text = "View"
+        btn.OnAction = "OpenAttachmentFromButton"
+    Else
+        btn.TextFrame.Characters.Text = "Browse"
+        btn.OnAction = "Attach_Design_Click"
+    End If
 End Sub

--- a/modMasterSync
+++ b/modMasterSync
@@ -31,7 +31,13 @@ Public Sub SyncMasterFromRoleSheet(ws As Worksheet, rng As Range)
                     With ws.Cells(r.Row, tbl.ListColumns(colIdx).Index)
                         Select Case tbl.ListColumns(colIdx).Name
                           Case "ProofPath","EmailPath","PrintPath"
-                            If .Hyperlinks.Count > 0 Then linkAddr = .Hyperlinks(1).Address Else linkAddr = ""
+                            If .Hyperlinks.Count > 0 Then
+                                linkAddr = .Hyperlinks(1).Address
+                            ElseIf Len(Trim(CStr(.Value))) > 0 Then
+                                linkAddr = CStr(.Value)
+                            Else
+                                linkAddr = ""
+                            End If
                             UpdateCellHyperlink newRow.Range.Cells(1, colIdx), linkAddr
                           Case Else
                             newRow.Range.Cells(1, colIdx).Value = .Value
@@ -58,6 +64,8 @@ Public Sub SyncMasterFromRoleSheet(ws As Worksheet, rng As Range)
                   Case "ProofPath","EmailPath","PrintPath"
                     If .Hyperlinks.Count > 0 Then
                         newVal = .Hyperlinks(1).Address
+                    ElseIf Len(Trim(CStr(.Value))) > 0 Then
+                        newVal = CStr(.Value)
                     Else
                         newVal = ""
                     End If
@@ -65,7 +73,7 @@ Public Sub SyncMasterFromRoleSheet(ws As Worksheet, rng As Range)
                         If .Hyperlinks.Count > 0 Then
                             oldVal = .Hyperlinks(1).Address
                         Else
-                            oldVal = ""
+                            oldVal = CStr(.Value)
                         End If
                     End With
                   Case Else


### PR DESCRIPTION
## Summary
- keep order-entry file paths when cells only contain text
- add `OpenAttachmentFromButton` helper
- render `Browse`/`View` buttons on the Design sheet
- initialize attachment buttons on workbook open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d7bd9d6508323bb4beac77fa3affa